### PR TITLE
Domain Change renew

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -154,7 +154,7 @@ func (w *AcmeWrapper) initACME(serverRunning bool) (err error) {
 	//  We start a quick custom server
 	// to get the initial certificates. In the future, we will use our custom SNI provider
 	// to not need a custom server (and not have any downtime) while updating
-	if w.CertNeedsUpdate() && !serverRunning {
+	if !serverRunning && w.CertNeedsUpdate() {
 		// Renew sets the config mutex, so unset it now
 		w.Unlock()
 		err = w.Renew()
@@ -176,7 +176,7 @@ func (w *AcmeWrapper) initACME(serverRunning bool) (err error) {
 	// between the above version and this one is that we use the custom provider if
 	// the server is already active rather than starting a new server.
 
-	if w.CertNeedsUpdate() && serverRunning {
+	if serverRunning && w.CertNeedsUpdate() {
 		w.Unlock()
 		err = w.Renew()
 		w.Lock()

--- a/acme.go
+++ b/acme.go
@@ -153,7 +153,7 @@ func (w *AcmeWrapper) initACME(serverRunning bool) (err error) {
 	// yet, since in this case we use the default SNI provider, which runs a custom server.
 	//  We start a quick custom server
 	// to get the initial certificates. In the future, we will use our custom SNI provider
-	// no not need a custom server (and not have any downtime) while updating
+	// to not need a custom server (and not have any downtime) while updating
 	if w.CertNeedsUpdate() && !serverRunning {
 		// Renew sets the config mutex, so unset it now
 		w.Unlock()

--- a/cert.go
+++ b/cert.go
@@ -98,5 +98,5 @@ func (w *AcmeWrapper) CertNeedsUpdate() bool {
 
 	// Now make sure that the domains in our config are entirely contained in the
 	// domains that this cert handles
-	return !arraySubset(domains, w.Config.Domains)
+	return !arraySubset(w.Config.Domains, domains)
 }

--- a/cert.go
+++ b/cert.go
@@ -55,8 +55,22 @@ func tlsCert(crt acme.CertificateResource) (*tls.Certificate, error) {
 	return &cert, err
 }
 
+// checks if a is a subset of b
+func arraySubset(a []string, b []string) bool {
+	if len(a) > len(b) {
+		return false
+	}
+	for _, i := range a {
+		if !stringInSlice(i, b) {
+			return false
+		}
+	}
+	return true
+}
+
 // CertNeedsUpdate returns whether the current certificate either
-// does not exist, or is <X days from expiration, where X is set up in config
+// does not exist, or is <X days from expiration, where X is set up in config,
+// or does not match the domains set up in configuration.
 func (w *AcmeWrapper) CertNeedsUpdate() bool {
 	if w.cert == nil {
 		// The cert doesn't exist - it certainly needs update
@@ -64,7 +78,11 @@ func (w *AcmeWrapper) CertNeedsUpdate() bool {
 	}
 
 	// w.cert.Leaf is not set, so we have to manually parse the certs
-	// and make sure that they don't expire soon
+	// and make sure that they don't expire soon.
+	// We also create a list of the domains in our certifiate, to make sure
+	// that the cert is for the correct ones!
+	domains := []string{}
+
 	for _, c := range w.cert.Certificate {
 		crt, err := x509.ParseCertificate(c)
 		if err != nil {
@@ -75,7 +93,10 @@ func (w *AcmeWrapper) CertNeedsUpdate() bool {
 		if timeLeft < w.Config.RenewTime {
 			return true
 		}
+		domains = append(domains, crt.DNSNames...)
 	}
 
-	return false
+	// Now make sure that the domains in our config are entirely contained in the
+	// domains that this cert handles
+	return !arraySubset(domains, w.Config.Domains)
 }


### PR DESCRIPTION
When a different domain is given to configuration, acmewrapper now checks to make sure that the old certificate contains the domain.

Fixes #8 