### PR TITLE
Fix compile error after changes in xenolf/lego

### DIFF
--- a/renew.go
+++ b/renew.go
@@ -64,7 +64,7 @@ func (w *AcmeWrapper) Renew() (err error) {
 
 	// TODO: In the future, figure out how to get renewals working with
 	// the information we have
-	cert, errmap := w.client.ObtainCertificate(w.Config.Domains, true, nil)
+	cert, errmap := w.client.ObtainCertificate(w.Config.Domains, true, nil, false)
 	err = getCertError(errmap)
 
 	if err != nil {
@@ -86,7 +86,7 @@ func (w *AcmeWrapper) Renew() (err error) {
 		}
 
 		// We agreed to new TOS. try again
-		cert, errmap = w.client.ObtainCertificate(w.Config.Domains, true, nil)
+		cert, errmap = w.client.ObtainCertificate(w.Config.Domains, true, nil, false)
 		err = getCertError(errmap)
 		if err != nil {
 			return err


### PR DESCRIPTION
I could make `MustStaple` a configurable parameter. For now, at least, with this makes the library usable, otherwise it does not compile.
